### PR TITLE
Remove NODE_ENV conditional so sequence timeline shows in `production`

### DIFF
--- a/theatre/core/src/sheetObjects/SheetObjectTemplate.ts
+++ b/theatre/core/src/sheetObjects/SheetObjectTemplate.ts
@@ -174,21 +174,17 @@ export default class SheetObjectTemplate {
    * Not available in core.
    */
   getMapOfValidSequenceTracks_forStudio(): IDerivation<IPropPathToTrackIdTree> {
-    if (process.env.NODE_ENV !== 'production') {
-      return this._cache.get('getMapOfValidSequenceTracks_forStudio', () =>
-        this.getArrayOfValidSequenceTracks().map((arr) => {
-          let map = {}
+    return this._cache.get('getMapOfValidSequenceTracks_forStudio', () =>
+      this.getArrayOfValidSequenceTracks().map((arr) => {
+        let map = {}
 
-          for (const {pathToProp, trackId} of arr) {
-            set(map, pathToProp, trackId)
-          }
+        for (const {pathToProp, trackId} of arr) {
+          set(map, pathToProp, trackId)
+        }
 
-          return map
-        }),
-      )
-    } else {
-      return new ConstantDerivation({})
-    }
+        return map
+      }),
+    )
   }
 
   getDefaultsAtPointer(


### PR DESCRIPTION
## What?
- [x] Remove `NODE_ENV` conditional guard from `getMapOfValidSequenceTracks_forStudio` method in `SheetObjectTemplate.ts` so sequence timeline shows up when `NODE_ENV` is set to `production` (useful for Create React App's where `NODE_ENV` is controlled by `react-scripts`)

Closes #26 

## Additional context
When building `examples/dom-cra` it now properly shows the timeline/sequence editor and keyframes are editable
![fix](https://user-images.githubusercontent.com/15909884/135648192-429ef107-3e1d-4c3c-baf0-dc0bc27fc7d3.PNG)