### PR TITLE
Improves scroll interaction for sequence editor

### DIFF
--- a/packages/playground/src/index.html
+++ b/packages/playground/src/index.html
@@ -7,6 +7,7 @@
         margin: 0;
         padding: 0;
         height: 100%;
+        background: black;
       }
     </style>
   </head>


### PR DESCRIPTION
## Changes
- Scroll paning (`shift + scroll`) is now synced for the keyframe viewport, easing viewport and scrollbar (Closes #22)
- Scroll zooming out (`ctrl + scroll down`) is now bounded to avoid zooming out to infinity  (Closes #19)

> There is still some quirky behaviour when using scroll to zoom inwards. It does not seem to respect the `pivotPointInUnitSpace` correctly. I've tried fixing it, but I've hit a dead end. 

## Changes in action:
![UbDKJoDwst](https://user-images.githubusercontent.com/837651/135715054-538268cb-a925-4595-896b-3903fa5d9b2f.gif)

All interactions in the recording is done via `ctrl + scroll` for zooming & `shift + scroll` for panning. 