### PR TITLE
Fixes inconsisten keyboard shortcuts for opening studio

### DIFF
--- a/theatre/studio/src/UIRoot/UIRoot.tsx
+++ b/theatre/studio/src/UIRoot/UIRoot.tsx
@@ -71,7 +71,7 @@ export default function UIRoot() {
   useEffect(() => {
     if (visiblityState === 'everythingIsHidden') {
       console.warn(
-        `Theatre Studio is hidden. You can restore it by either hitting alt/option+\` or calling studio.ui.restore()`,
+        `Theatre Studio is hidden. Use the keyboard shortcut 'alt + \\' to restore the studio, or call studio.ui.restore().`,
       )
     }
     return () => {}

--- a/theatre/studio/src/UIRoot/useKeyboardShortcuts.ts
+++ b/theatre/studio/src/UIRoot/useKeyboardShortcuts.ts
@@ -44,7 +44,12 @@ export default function useKeyboardShortcuts() {
         } else {
           return
         }
-      } else if (e.key === `'` && e.altKey) {
+      }
+      // alt + \
+      else if (
+        e.altKey &&
+        (e.key === '\\' || e.code === 'Backslash' || e.code === 'IntlBackslash')
+      ) {
         studio.transaction(({stateEditors, drafts}) => {
           stateEditors.studio.ahistoric.setVisibilityState(
             drafts.ahistoric.visibilityState === 'everythingIsHidden'


### PR DESCRIPTION
Adds support for `alt + \` by key (while still supporting the old shortcut `e.code === 'Backslash'` and adding support for `e.code === 'IntlBackslash'`).

Updates the logged message when the studio is hidden:
> Theatre Studio is hidden. Use the keyboard shortcut 'alt + \\' to restore the studio, or call studio.ui.restore().

With these changes, `alt + \` should in *most cases* toggle the studio visibility.

related to #34