### PR TITLE
R3F: Add ability to provide additional props to sheet object and get sheet ref

### DIFF
--- a/packages/r3f/src/components/editable.tsx
+++ b/packages/r3f/src/components/editable.tsx
@@ -85,7 +85,7 @@ const editable = <
         useEditorStore
           .getState()
           .setSheetObject(uniqueName, sheetObject as $FixMe)
-      }, [sheet, uniqueName, additionalProps])
+      }, [sheet, uniqueName])
 
       const transformDeps: string[] = []
 


### PR DESCRIPTION
## What?
- [x] Add ability to provide additional props to R3F components that use the `editable` extension to be able to add custom props to the `sheet.object`
- [x] Add ability to get the sheet ref from the component by providing a ref to the component


![additional_props](https://user-images.githubusercontent.com/15909884/137030876-d4a54d37-0bec-4e4d-bdf8-c99114004ffa.PNG)
> Example of custom `shadows` prop being used on the  `<e.mesh>` element in the playground example

## How to use?
```jsx
function App(){
  const sheetRef = useRef();

  useEffect(() => {
    sheetRef.current.onValuesChange(newValues => {
      console.log(newValues)
    });
  }, [sheetRef ])

  return(
  <e.group additionalProps={{ someCustomProp: 'yay' }} objRef={sheetRef} />
  )
}
```
