### PR TITLE
Potential fix for architecture like nextjs?

### DIFF
--- a/packages/dataverse/package.json
+++ b/packages/dataverse/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/AriaMinaei/theatre",
     "directory": "packages/dataverse"
   },
+  { 
+   "type": "module",
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
If I try to use theatre on NextJS I randomly get the following error (not always weirdly):
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /.../node_modules/lodash-es/get.js from /.../node_modules/@theatre/dataverse/dist/index.js not supported.
Instead change the require of get.js in /.../node_modules/@theatre/dataverse/dist/index.js to a dynamic import() which is available in all CommonJS modules.
```

The error happened to other developers in my company, and with a different setup of NextJS.

I am totally not sure about my PR, it's just an idea feel free to close it for a proper fix.

This triggers the error:
`import { types as type } from '@theatre/core'`
A temporary fix is to use require instead:
` const { types: type } = require('@theatre/core')`

FYI we use lodash-es as a dependency in our project