### PR TITLE
Added an optional config the R3F sheet context

### DIFF
--- a/packages/r3f/src/main/SheetProvider.tsx
+++ b/packages/r3f/src/main/SheetProvider.tsx
@@ -9,11 +9,20 @@ import {useThree} from '@react-three/fiber'
 import type {ISheet} from '@theatre/core'
 import {bindToCanvas} from './store'
 
-const ctx = createContext<{sheet: ISheet}>(undefined!)
+export type R3FSheetConfig = {
+  namespacePrefix?: string; 
+}
 
-const useWrapperContext = (): {sheet: ISheet} => {
+export type R3FSheetContext = {
+  sheet: ISheet,
+  config?: R3FSheetConfig
+}
+
+const ctx = createContext<R3FSheetContext>(undefined!)
+
+const useWrapperContext = (): R3FSheetContext => {
   const val = useContext(ctx)
-  if (!val) {
+  if (!val || !val.sheet) {
     throw new Error(
       `No sheet found. You need to add a <SheetProvider> higher up in the tree. https://docs.theatrejs.com/r3f.html#sheetprovider`,
     )
@@ -25,10 +34,17 @@ export const useCurrentSheet = (): ISheet | undefined => {
   return useWrapperContext().sheet
 }
 
+export const useCurrentR3FSheetConfig = (): R3FSheetConfig | undefined => {
+  return useWrapperContext().config
+}
+
+
+
 const SheetProvider: React.FC<{
   sheet: ISheet
   children: ReactNode
-}> = ({sheet, children}) => {
+  config?: R3FSheetConfig
+}> = ({sheet, children, config}) => {
   const {scene, gl} = useThree((s) => ({scene: s.scene, gl: s.gl}))
 
   useEffect(() => {
@@ -41,7 +57,7 @@ const SheetProvider: React.FC<{
     bindToCanvas({gl, scene})
   }, [scene, gl])
 
-  return <ctx.Provider value={{sheet}}>{children}</ctx.Provider>
+  return <ctx.Provider value={{sheet, config}}>{children}</ctx.Provider>
 }
 
 export default SheetProvider

--- a/packages/r3f/src/main/editable.tsx
+++ b/packages/r3f/src/main/editable.tsx
@@ -4,7 +4,7 @@ import React, {forwardRef, useEffect, useLayoutEffect, useRef} from 'react'
 import {allRegisteredObjects, editorStore} from './store'
 import {mergeRefs} from 'react-merge-refs'
 import useInvalidate from './useInvalidate'
-import {useCurrentSheet} from './SheetProvider'
+import {useCurrentR3FSheetConfig, useCurrentSheet} from './SheetProvider'
 import defaultEditableFactoryConfig from './defaultEditableFactoryConfig'
 import type {EditableFactoryConfig} from './editableFactoryConfigUtils'
 import {makeStoreKey} from './utils'
@@ -75,17 +75,20 @@ const createEditable = <Keys extends keyof JSX.IntrinsicElements>(
         const objectRef = useRef<JSX.IntrinsicElements[U]>()
 
         const sheet = useCurrentSheet()!
+        const sheetConfig = useCurrentR3FSheetConfig()
         const rafDriver = useCurrentRafDriver()
 
         const [sheetObject, setSheetObject] = useState<
           undefined | ISheetObject<$FixMe>
         >(undefined)
+        
+        const keyPrefix = sheetConfig?.namespacePrefix ? `${sheetConfig.namespacePrefix} / ` : ''
 
         const storeKey = useMemo(
           () =>
             makeStoreKey({
               ...sheet.address,
-              objectKey: theatreKey as $IntentionalAny,
+              objectKey: `${keyPrefix}${theatreKey}` as $IntentionalAny,
             }),
           [sheet, theatreKey],
         )


### PR DESCRIPTION
This PR adds an optional config to the sheet context in the R3F package with the option for a namespace prefix. When using the library I like the ability to group objects by namespace but it's tedious to do that for ever object in a scene. The SheetProvider seemed the most sensible place to add this option and I opted to make it a whole config so it could be expanded in the future to include other options.

```jsx
<SheetProvider config={{namespacePrefix: "3D Scene"}} sheet={getProject('Demo Project').sheet('Demo Sheet')}>
```
 In the future, it might make sense to rename `SheetProvider` to `R3FSheetProvider`, or something similar, to avoid confusion from users who might want to use the provider outside of fiber. 

Note: I was not able to properly setup the repo because I encountered this error when trying to run yarn: `Workspaces can only be enabled in private projects.`. I don't normally use yarn and I'm not sure what the issue is.