### PR TITLE
fix crash in shared/dom route (#491)

### DIFF
--- a/packages/playground/src/shared/dom/Scene.tsx
+++ b/packages/playground/src/shared/dom/Scene.tsx
@@ -1,7 +1,13 @@
-import { getStudioSync} from '@theatre/core'
+import {getStudio, getStudioSync} from '@theatre/core'
 import type {UseDragOpts} from './useDrag'
 import useDrag from './useDrag'
-import React, {useLayoutEffect, useMemo, useRef, useState} from 'react'
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import type {
   IProject,
   ISheet,
@@ -182,10 +188,14 @@ export const Scene: React.FC<{project: IProject}> = ({project}) => {
   const sheet = project.sheet('Scene', 'default')
   const [selection, setSelection] = useState<IStudio['selection']>()
 
-  useLayoutEffect(() => {
-    return getStudioSync()!.onSelectionChange((newState) => {
-      setSelection(newState)
+  useEffect(() => {
+    let unsubscribe = () => {}
+    getStudio().then((studio) => {
+      unsubscribe = studio.onSelectionChange((newState) => {
+        setSelection(newState)
+      })
     })
+    return () => unsubscribe()
   }, [])
 
   const containerRef = useRef<HTMLDivElement>(null!)

--- a/packages/playground/src/shared/dom/index.tsx
+++ b/packages/playground/src/shared/dom/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import theatre from '@theatre/core'
+import '@theatre/studio'
 import {getProject} from '@theatre/core'
 import {Scene} from './Scene'
 


### PR DESCRIPTION
This PR fixes a crash where the DOM playground scene wouldn’t load due to a Studio initialization race condition.

What’s changed:

In Scene.tsx, replaced getStudioSync() with an async getStudio().then() call so we wait for Studio to initialize before using it — preventing the “undefined” access crash.

In index.tsx, added import '@theatre/studio' to ensure the Studio bundle is included in the build, fixing the 404s and the “Project state is empty” issue.